### PR TITLE
FAI-2895 Updated API deadline from "31 Oct 2025" to "31 Jan 2026"

### DIFF
--- a/src/SFA.DAS.Apim.Developer.Web/TagHelpers/ApiDescriptionHelper.cs
+++ b/src/SFA.DAS.Apim.Developer.Web/TagHelpers/ApiDescriptionHelper.cs
@@ -51,11 +51,15 @@ namespace SFA.DAS.Apim.Developer.Web.TagHelpers
         public static Dictionary<string, string> Descriptions => new()
         {
             // This overrides the product descriptions drawn from the swagger doc annotations on each products' Program class in das-apim-endpoints.
-            // Sandbox environments don't exist in APIM and so their descriptions must be overidden.
+            // Sandbox environments don't exist in APIM and so their descriptions must be overridden.
             { "VacanciesManageOuterApi-Sandbox", "Test your implementation of the Recruitment API." },
             {
                 "VacanciesOuterApi",
-                "Get and display adverts from Find an apprenticeship. <div class='govuk-inset-text'><p>The new API version (version 2) lets you display apprenticeships that are available in more than one location.</p><p>You must update to this new version by 31 October 2025. Read more about changing the version you use in the Versioning section of this page.</p><p>If you need to check your current implementation, you can view the old documentation for <a class='govuk-link' href='{url}'>Display advert API (version 1)</a></p></div>"
+                "Get and display adverts from Find an apprenticeship. <div class='govuk-inset-text'>" +
+                "<p>The new API version (version 2) lets you display apprenticeships that are available in more than one location.</p>" +
+                "<p>You must update to this new version by 31 January 2026. Read more about changing the version you use in the Versioning section of this page.</p>" +
+                "<p>If you need to check your current implementation, you can view the old documentation for " +
+                "<a class='govuk-link' href='{url}'>Display advert API (version 1)</a></p></div>"
             },
             { "TrackProgressOuterApi-Sandbox", "Test your implementation of the Track apprenticeship progress API." },
             { "TrackProgressOuterApi", "Share data on the progress of your apprenticeships." }

--- a/src/SFA.DAS.Apim.Developer.Web/TagHelpers/ApiDescriptionHelper.cs
+++ b/src/SFA.DAS.Apim.Developer.Web/TagHelpers/ApiDescriptionHelper.cs
@@ -57,7 +57,7 @@ namespace SFA.DAS.Apim.Developer.Web.TagHelpers
                 "VacanciesOuterApi",
                 "Get and display adverts from Find an apprenticeship. <div class='govuk-inset-text'>" +
                 "<p>The new API version (version 2) lets you display apprenticeships that are available in more than one location.</p>" +
-                "<p>You must update to this new version by 31 January 2026. Read more about changing the version you use in the Versioning section of this page.</p>" +
+                "<p>You must update to this new version by 30 January 2026. Read more about changing the version you use in the Versioning section of this page.</p>" +
                 "<p>If you need to check your current implementation, you can view the old documentation for " +
                 "<a class='govuk-link' href='{url}'>Display advert API (version 1)</a></p></div>"
             },


### PR DESCRIPTION
✏️ Fix typo and update API description details

- Corrected "overidden" to "overridden" in a comment
- Updated API deadline from "31 Oct 2025" to "31 Jan 2026"
- Improved description formatting for better readability

Changes made by Balaji Jambulingam